### PR TITLE
feat: tool to prebuild spendies for deora

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "./scripts/test.sh",
-    "compile:contracts": "./node_modules/.bin/truffle compile"
+    "compile:contracts": "./node_modules/.bin/truffle compile && node scripts/createContracts"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/scripts/createContracts.js
+++ b/scripts/createContracts.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { bufferToHex, ripemd160 } = require("ethereumjs-util");
+
+const contracts = [
+  { 
+    name: 'BallotBox',
+    truffleJson: require("../build/contracts/BallotBox"),
+    keys: {    
+      VOICE_CREDITS: "1231111111111111111111111111111111111123",
+      VOICE_TOKENS: "2341111111111111111111111111111111111234",
+      BALANCE_CARD: "3451111111111111111111111111111111111345",
+      OPERATOR: "7891111111111111111111111111111111111789",
+      TRASH_BOX: '4561111111111111111111111111111111111456',
+      MOTION_ID: "deadbeef0001",
+      IS_YES: "deadbeef0002"
+    },
+    values: {
+      VOICE_CREDITS: "0x8f8FDcA55F0601187ca24507d4A1fE1b387Db90B",
+      VOICE_TOKENS: "0x3442c197cc858bED2476BDd9c7d4499552780f3D",
+      BALANCE_CARD: "0xCD1b3a9a7B5f84BC7829Bc7e6e23adb1960beE97",
+      OPERATOR: "0x0d56caf1ccb9eddf27423a1d0f8960554e7bc9d5",
+      TRASH_BOX: "0x0d56caf1ccb9eddf27423a1d0f8960554e7bc9d5",
+      MOTION_ID: "deadbeef0001",
+      IS_YES: "deadbeef0002"
+    }
+  },
+  { 
+    name: 'VotingBooth',
+    truffleJson: require("../build/contracts/VotingBooth"),
+    keys: {
+      VOICE_CREDITS: "1231111111111111111111111111111111111123",
+      VOICE_TOKENS: "2341111111111111111111111111111111111234",
+      BALANCE_CARD: "3451111111111111111111111111111111111345",
+      YES_BOX: "4561111111111111111111111111111111111456",
+      NO_BOX: "5671111111111111111111111111111111111567",
+      OPERATOR: "7891111111111111111111111111111111111789",
+      PROPOSAL_ID: "deadbeef0001"
+    },
+    values: {
+      VOICE_CREDITS: "0x8f8FDcA55F0601187ca24507d4A1fE1b387Db90B",
+      VOICE_TOKENS: "0x3442c197cc858bED2476BDd9c7d4499552780f3D",
+      BALANCE_CARD: "0xCD1b3a9a7B5f84BC7829Bc7e6e23adb1960beE97",
+      YES_BOX: "4561111111111111111111111111111111111456",
+      NO_BOX: "5671111111111111111111111111111111111567",
+      OPERATOR: "0x0d56caf1ccb9eddf27423a1d0f8960554e7bc9d5",
+      PROPOSAL_ID: "deadbeef0001"
+    }
+  }
+]
+
+const outdir = process.argv[2] || "./build/spendies";
+
+try { fs.mkdirSync(outdir); } catch (e) { }
+
+const replaceAll = (str, find, replace) =>
+  str.replace(new RegExp(find, "g"), replace.replace("0x", "").toLowerCase());
+
+
+for (let contract of contracts) {
+  let code = contract.truffleJson.deployedBytecode;
+  
+  Object.keys(contract.keys).forEach((k) => {
+    console.log(k.padEnd(20, ' '), contract.keys[k], contract.values[k]);
+    code = replaceAll(code, contract.keys[k], contract.values[k]);
+  });
+  const contractAddr = bufferToHex(ripemd160(code));
+
+  const outFile = path.join(outdir, `${contract.name}.js`);
+  fs.writeFileSync(
+    outFile,
+`
+const code = '${code}';
+
+const keys = ${JSON.stringify(contract.keys, null, 2)};
+
+const replaceAll = (str, find, replace) =>
+  str.replace(new RegExp(find, "g"), replace.replace("0x", "").toLowerCase());
+    
+module.exports = { 
+  address: '${contractAddr}',
+  code,
+  keys,
+  abi: ${JSON.stringify(contract.truffleJson.abi, null, 2)},
+  withParams: (params) => {
+    let codeCopy = code;
+    Object.keys(params).forEach((k) => {
+      console.log(k.padEnd(20, ' '), keys[k], params[k]);
+      codeCopy = replaceAll(codeCopy, keys[k], params[k]);
+    });
+    return codeCopy;
+  }
+};
+`
+  );
+  console.log(`${contract.name} exported to ${outFile}\n`);
+}

--- a/test/ballotBox.js
+++ b/test/ballotBox.js
@@ -16,13 +16,13 @@ const should = chai
   .should();
 
 function replaceAll(str, find, replace) {
-    return str.replace(new RegExp(find, 'g'), replace.replace('0x', ''));
+    return str.replace(new RegExp(find, 'g'), replace.replace('0x', '').toLowerCase());
 }
 
 
 contract('Ballot Box', (accounts) => {
   const voter = accounts[1];
-  const TRASH_BOX = '0xDB3D918dF2cb3E5486CfC39b188c6f2B268a6511'; // eco system multisig
+  const TRASH_BOX = '0x0d56caf1ccb9eddf27423a1d0f8960554e7bc9d5'; // eco system multisig
   const balanceCardId = 123;
   const voterPriv = '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201';
   const voiceBudget = '400000000000000000000';
@@ -47,33 +47,6 @@ contract('Ballot Box', (accounts) => {
 
   it('should allow to withdraw yes votes', async () => {
 
-
-    let motionId = `0x000000000000`;
-
-    let code = BallotBox._json.deployedBytecode;
-    // console.log('raw box: ', code);
-    const voiceCredAddr = '0x8f8FDcA55F0601187ca24507d4A1fE1b387Db90B';
-    const votesAddr = '0x3442c197cc858bED2476BDd9c7d4499552780f3D';
-    const balCardAddr = '0xCD1b3a9a7B5f84BC7829Bc7e6e23adb1960beE97';
-    const isYes = false;
-    // replace token address placeholder to real token address
-    code = replaceAll(code, '1231111111111111111111111111111111111123', voiceCredAddr.replace('0x', '').toLowerCase());
-    code = replaceAll(code, '2341111111111111111111111111111111111234', votesAddr.replace('0x', '').toLowerCase());
-    code = replaceAll(code, '3451111111111111111111111111111111111345', balCardAddr.replace('0x', '').toLowerCase());
-    code = replaceAll(code, '4561111111111111111111111111111111111456', TRASH_BOX.replace('0x', '').toLowerCase());
-    if (isYes) {
-      code = replaceAll(code, 'deadbeef0002', YES);
-    } else {
-      code = replaceAll(code, 'deadbeef0002', NO);
-    }
-    
-    code = replaceAll(code, 'deadbeef0001', motionId);
-    // console.log('code: ', code);
-    const script = Buffer.from(code.replace('0x', ''), 'hex');
-    const scriptHash = ethUtil.ripemd160(script);
-    console.log(`box ${isYes} contract address: 0x${scriptHash.toString('hex')}`);
-
-
     motionId = `0x00000000013E`;
 
     // deploy vote contract
@@ -82,7 +55,7 @@ contract('Ballot Box', (accounts) => {
     tmp = replaceAll(tmp, '1231111111111111111111111111111111111123', voiceCredits.address);
     tmp = replaceAll(tmp, '2341111111111111111111111111111111111234', votes.address);
     tmp = replaceAll(tmp, '3451111111111111111111111111111111111345', balanceCards.address);
-    tmp = replaceAll(tmp, '4561111111111111111111111111111111111456', TRASH_BOX.replace('0x', '').toLowerCase());
+    tmp = replaceAll(tmp, '4561111111111111111111111111111111111456', TRASH_BOX);
     tmp = replaceAll(tmp, 'deadbeef0001', motionId);
     tmp = replaceAll(tmp, 'deadbeef0002', YES);
     BallotBox._json.bytecode = tmp;
@@ -138,7 +111,7 @@ contract('Ballot Box', (accounts) => {
     tmp = replaceAll(tmp, '1231111111111111111111111111111111111123', voiceCredits.address);
     tmp = replaceAll(tmp, '2341111111111111111111111111111111111234', votes.address);
     tmp = replaceAll(tmp, '3451111111111111111111111111111111111345', balanceCards.address);
-    tmp = replaceAll(tmp, '4561111111111111111111111111111111111456', TRASH_BOX.replace('0x', '').toLowerCase());
+    tmp = replaceAll(tmp, '4561111111111111111111111111111111111456', TRASH_BOX);
     tmp = replaceAll(tmp, 'deadbeef0001', motionId);
     tmp = replaceAll(tmp, 'deadbeef0002', YES);
     BallotBox._json.bytecode = tmp;
@@ -190,7 +163,7 @@ contract('Ballot Box', (accounts) => {
     tmp = replaceAll(tmp, '1231111111111111111111111111111111111123', voiceCredits.address);
     tmp = replaceAll(tmp, '2341111111111111111111111111111111111234', votes.address);
     tmp = replaceAll(tmp, '3451111111111111111111111111111111111345', balanceCards.address);
-    tmp = replaceAll(tmp, '4561111111111111111111111111111111111456', TRASH_BOX.replace('0x', '').toLowerCase());
+    tmp = replaceAll(tmp, '4561111111111111111111111111111111111456', TRASH_BOX);
     tmp = replaceAll(tmp, 'deadbeef0001', motionId);
     tmp = replaceAll(tmp, 'deadbeef0002', NO);
     BallotBox._json.bytecode = tmp;
@@ -237,7 +210,7 @@ contract('Ballot Box', (accounts) => {
     // deploy earth
     let tmp = BallotBox._json.bytecode;
     // replace token address placeholder to real token address
-    tmp = replaceAll(tmp, '7891111111111111111111111111111111111789', voter.replace('0x', ''));
+    tmp = replaceAll(tmp, '7891111111111111111111111111111111111789', voter);
     BallotBox._json.bytecode = tmp;
     const boxContract = await BallotBox.new();
 

--- a/test/votingBooth.js
+++ b/test/votingBooth.js
@@ -16,7 +16,7 @@ const should = chai
   .should();
 
 function replaceAll(str, find, replace) {
-    return str.replace(new RegExp(find, 'g'), replace.replace('0x', ''));
+    return str.replace(new RegExp(find, 'g'), replace.replace('0x', '').toLowerCase());
 }
 
 
@@ -47,27 +47,6 @@ contract('Voting Booth', (accounts) => {
   it('should allow to cast ballot', async () => {
 
     const motionId = `000000000000`;
-
-    let code = VotingBooth._json.deployedBytecode;
-    // console.log('raw booth: ', code);
-    const voiceCredAddr = '0x8f8FDcA55F0601187ca24507d4A1fE1b387Db90B';
-    const votesAddr = '0x3442c197cc858bED2476BDd9c7d4499552780f3D';
-    const balCardAddr = '0xCD1b3a9a7B5f84BC7829Bc7e6e23adb1960beE97';
-    const yesBoxAddr = '0x519d77c37bb49d559dade00fa155e0e370e9a531';
-    const noBoxAddr = '0xb4c625b6c18f30477dc530471315ccbf18f81a21';
-
-    // replace token address placeholder to real token address
-    code = replaceAll(code, '1231111111111111111111111111111111111123', voiceCredAddr.replace('0x', '').toLowerCase());
-    code = replaceAll(code, '2341111111111111111111111111111111111234', votesAddr.replace('0x', '').toLowerCase());
-    code = replaceAll(code, '3451111111111111111111111111111111111345', balCardAddr.replace('0x', '').toLowerCase());
-    code = replaceAll(code, '4561111111111111111111111111111111111456', yesBoxAddr.replace('0x', '').toLowerCase());
-    code = replaceAll(code, '5671111111111111111111111111111111111567', noBoxAddr.replace('0x', '').toLowerCase());
-    code = replaceAll(code, 'deadbeef0001', motionId);
-    // console.log('code: ', code);
-    const script = Buffer.from(code.replace('0x', ''), 'hex');
-    const scriptHash = ethUtil.ripemd160(script);
-    console.log(`booth contract address: 0x${scriptHash.toString('hex')}`);
-
 
     // deploy vote contract
     let tmp = VotingBooth._json.bytecode;


### PR DESCRIPTION
On `yarn compile:contracts` it also prepares a special file per spendie: `build/spendies/<Name>.js`.

If imported on a frontend it provides:
- spendie abi
- spendie address
- bytecode with basic placeholders replaced (token addresses)
- `withParams` function which replaces the rest of the placeholders on request:

```js
const VotingBooth = require('./build/spendies/VotingBooth');

// read things
const { abi, address, code } = VotingBooth;

// replace the rest of placeholders (if any)
const spendieWithYesAndNoBoxes = VotingBooth.withParams({ 
  YES_BOX: '0xcdcebc9492d0671eaaf837aaebb876458fc84a5d', 
  NO_BOX: '0xcdcebc9492d0671eaaf837aaebb876458fc84a5d'
});

// new code, new address
const { abi, address, code } = spendieWithYesAndNoBoxes;

// chainable
const spendieWithYesAndNoBoxes = VotingBooth
  .withParams({ 
    YES_BOX: '0xcdcebc9492d0671eaaf837aaebb876458fc84a5d'
  })
  .withParams({ 
    NO_BOX: '0xcdcebc9492d0671eaaf837aaebb876458fc84a5d'
  })
```


Foundation for https://github.com/leapdao/spending-conditions/issues/15