### PR TITLE
feat: add script to extract and aggregate vote data

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "chai-as-promised": "^7.1.1",
     "ethereumjs-util": "^6.0.0",
     "ganache-cli": "^6.4.1",
+    "leap-core": "^0.35.1",
+    "leap-provider": "^1.1.1",
     "truffle": "^5.0.7"
   },
   "dependencies": {

--- a/scripts/scanResults.js
+++ b/scripts/scanResults.js
@@ -188,7 +188,7 @@ const getProposalId = (tx, proposals, voter) => {
   votesWithDefault = votesWithDefault.concat(votes);  
   
   fs.writeFileSync(`./build/rawVotes.csv`, votesWithDefault.filter(v => !!v).map(v => 
-    `${v.proposalId};${v.voter};${v.type};${v.votes}`  
+    `${v.proposalId},${v.voter},${v.type},${v.votes}`  
   ).join('\n'));
 
   const groupedDistr = Object.entries(distr).map(([proposalId, votes]) => 
@@ -196,8 +196,8 @@ const getProposalId = (tx, proposals, voter) => {
   );
 
 
-  const distributionByVoteCSV = [].concat(...groupedDistr.map((v) =>
-      Object.entries(v.distr).map(([votes, count]) => `${v.proposalId};${votes};${count}`)
+  const distributionByVoteCSV = [`Proposal,Votes,Count`].concat(...groupedDistr.map((v) =>
+      Object.entries(v.distr).map(([votes, count]) => `${v.proposalId},${votes},${count}`)
   ));
   
   fs.writeFileSync(`./build/distributionByVote.csv`, distributionByVoteCSV.join('\n'))
@@ -210,7 +210,7 @@ const getProposalId = (tx, proposals, voter) => {
   ));
 
   fs.writeFileSync(`./build/distr.csv`, flatDistr.map(v => 
-    `${v[0]};${v[1]};${v[2]}`  
+    `${v[0]},${v[1]},${v[2]}`  
   ).join('\n'));
 
   console.log("total txs: ", txs.length);

--- a/scripts/scanResults.js
+++ b/scripts/scanResults.js
@@ -191,10 +191,11 @@ const getProposalId = (tx, proposals, voter) => {
     `${v.proposalId},${v.voter},${v.type},${v.votes}`  
   ).join('\n'));
 
-  const groupedDistr = Object.entries(distr).map(([proposalId, votes]) => 
-    ({ proposalId, distr: countByNumberOfVotes(Object.entries(votes)) })
+  const groupedDistr = Object.keys(distr)
+    .sort()
+    .map((proposalId) => 
+    ({ proposalId, distr: countByNumberOfVotes(Object.entries(distr[proposalId])) })
   );
-
 
   const distributionByVoteCSV = [`Proposal,Votes,Count`].concat(...groupedDistr.map((v) =>
       Object.entries(v.distr)

--- a/scripts/scanResults.js
+++ b/scripts/scanResults.js
@@ -191,12 +191,16 @@ const getProposalId = (tx, proposals, voter) => {
     `${v.proposalId},${v.voter},${v.type},${v.votes}`  
   ).join('\n'));
 
-  const groupedDistr = Object.keys(distr)
+  // distr is a Map<proposalId: string, Map<voter: address, vote: number>>
+  // groupedDistr is a [{ proposalId:string, distr: Map<vote: number, count: number>}]
+  // where `count` is a number of users who put`vote` number of votes for `proposalId`
+  const groupedDistr = Object.keys(distrs)
     .sort()
     .map((proposalId) => 
     ({ proposalId, distr: countByNumberOfVotes(Object.entries(distr[proposalId])) })
   );
 
+  // squash `groupedDistr` with proposal id and dump to CSV
   const distributionByVoteCSV = [`Proposal,Votes,Count`].concat(...groupedDistr.map((v) =>
       Object.entries(v.distr)
         .sort((a, b) => a[0] - b[0])

--- a/scripts/scanResults.js
+++ b/scripts/scanResults.js
@@ -197,7 +197,9 @@ const getProposalId = (tx, proposals, voter) => {
 
 
   const distributionByVoteCSV = [`Proposal,Votes,Count`].concat(...groupedDistr.map((v) =>
-      Object.entries(v.distr).map(([votes, count]) => `${v.proposalId},${votes},${count}`)
+      Object.entries(v.distr)
+        .sort((a, b) => a[0] - b[0])
+        .map(([votes, count]) => `${v.proposalId},${votes},${count}`)
   ));
   
   fs.writeFileSync(`./build/distributionByVote.csv`, distributionByVoteCSV.join('\n'))

--- a/scripts/scanResults.js
+++ b/scripts/scanResults.js
@@ -194,11 +194,14 @@ const getProposalId = (tx, proposals, voter) => {
   // distr is a Map<proposalId: string, Map<voter: address, vote: number>>
   // groupedDistr is a [{ proposalId:string, distr: Map<vote: number, count: number>}]
   // where `count` is a number of users who put`vote` number of votes for `proposalId`
-  const groupedDistr = Object.keys(distrs)
+  const groupedDistr = Object.keys(distr)
     .sort()
-    .map((proposalId) => 
-    ({ proposalId, distr: countByNumberOfVotes(Object.entries(distr[proposalId])) })
-  );
+    .map((proposalId) => {
+      let countByVote = countByNumberOfVotes(Object.entries(distr[proposalId]));
+      const totalVotesForProposal = Object.values(countByVote).reduce((r, v) => r +=v, 0);
+      countByVote[0] = (countByVote[0] || 0) + voters.size - totalVotesForProposal;
+      return { proposalId, distr: countByVote };
+    });
 
   // squash `groupedDistr` with proposal id and dump to CSV
   const distributionByVoteCSV = [`Proposal,Votes,Count`].concat(...groupedDistr.map((v) =>

--- a/scripts/scanResults.js
+++ b/scripts/scanResults.js
@@ -1,0 +1,220 @@
+const fs = require('fs');
+const https = require('https');
+const ethers = require('ethers');
+const { Tx } = require("leap-core");
+const LeapProvider = require("leap-provider");
+const { bufferToHex, ripemd160 } = require('ethereumjs-util');
+
+const boothAbi = require('../build/contracts/VotingBooth').abi;
+const boxAbi = require('../build/contracts/BallotBox').abi;
+
+/** Params */
+const proposalData = 'https://www.npoint.io/documents/217ecb17f01746799a3b';
+const proposalsFile = 'build/proposals.json';
+const votesFile = 'build/voteTxs.json';
+const leapNetworkNode = 'https://testnet-node.leapdao.org';
+const startBlock = 88632; // September 8, 2019, 10:39:33 UTC
+const endBlock = 90780; // September 9, 2019, 16:00:41 UTC
+/** ---------------- */
+
+const factor18 = ethers.utils.bigNumberify(String(10 ** 18));
+
+const plasma = new LeapProvider(leapNetworkNode);
+
+const booth = new ethers.utils.Interface(boothAbi);
+const voteFuncSig = booth.functions.castBallot.sighash.replace('0x', '');
+
+const box = new ethers.utils.Interface(boxAbi);
+const withdrawFuncSig = box.functions.withdraw.sighash.replace('0x', '');
+
+const getFuncSig = tx => 
+  tx.inputs[0].msgData.slice(0, 4).toString('hex');
+
+const isSpendie = tx => tx.type === 13;
+
+const isVote = tx => isSpendie(tx) && getFuncSig(tx) === voteFuncSig;
+
+const isWithdraw = tx => isSpendie(tx) && getFuncSig(tx) === withdrawFuncSig;
+
+const slimTx = ({ hash, blockHash, blockNumber, from, to, raw }) => ({
+  hash, blockHash, blockNumber, from, to, raw
+});
+
+const downloadTxs = async () => {
+  let txs = [];
+  for (let blockNum = startBlock; blockNum <= endBlock; blockNum++) {
+    txs = txs.concat(
+      (await plasma.getBlock(blockNum, true)).transactions.map(slimTx)
+    );
+    process.stdout.write(`\rDownloading block: ${blockNum}`);
+  }
+  console.log();
+  fs.writeFileSync(`./${votesFile}`, JSON.stringify(txs, null, 2));
+  return txs;
+};
+
+const getTxData = () => {
+  if (fs.existsSync(`./${votesFile}`)) {
+    return require(`../${votesFile}`);
+  }
+  return downloadTxs();
+};
+
+const slimProposal = ({ 
+  title, proposalId, boothAddress, yesBoxAddress, noBoxAddress
+}) => ({
+  title, proposalId, boothAddress, yesBoxAddress, noBoxAddress
+});
+
+const downloadProposals = async () => {
+  return new Promise((resolve, reject) => 
+    https.get(proposalData, (res) => {
+      let raw = '';
+      res.on('data', d => raw += d);
+      res.on('end', () => resolve(JSON.parse(raw)));
+      res.on('error', e => reject(e));
+    })
+  );  
+};
+
+const getProposals = async () => {
+  if (fs.existsSync(`./${proposalsFile}`)) {
+    return require(`../${proposalsFile}`);
+  }
+  
+  const rawProps = await downloadProposals();
+  const proposals = rawProps.contents.proposals
+    .filter(p => p.proposalId)
+    .map(slimProposal);
+
+  fs.writeFileSync(`./${proposalsFile}`, JSON.stringify(proposals, null, 2));
+  return proposals;
+};
+
+const getVotes = (tx) => {
+  // vote is a 4th argument (index 3) to castBallot/withdraw call
+  const votes = ethers.utils.defaultAbiCoder.decode(
+    booth.functions.castBallot.inputs.map(i => i.type),
+    bufferToHex(tx.inputs[0].msgData.slice(4)) // cut a func sig
+  )[3].div(factor18).toNumber();
+
+  return isWithdraw(tx) ? -votes : votes;
+};
+
+const getProposalByBox = (proposals, boxAddress) =>
+  proposals.find((prop) => 
+      prop.yesBoxAddress === boxAddress 
+      || prop.noBoxAddress === boxAddress
+  );
+
+const countByNumberOfVotes = (arr) => 
+  arr.reduce((r, v) => {
+    r[v[1]] = (r[v[1]] || 0) + 1;
+    return r;
+  }, {});
+
+const getBoxAddress = (tx, voter) => {
+  if (isWithdraw(tx)) {
+    return bufferToHex(ripemd160(tx.inputs[0].script));
+  }
+  return tx.outputs.find(o => o.address !== voter && o.color === 4).address;
+};
+
+const getProposalId = (tx, proposals, voter) => {
+  const boxAddr = getBoxAddress(tx, voter);
+  const { proposalId } = getProposalByBox(proposals, boxAddr) || {};
+  if (proposalId) {
+    return proposalId;
+  }
+  console.warn(
+    'Unknown proposal vote',
+    JSON.stringify({ boxAddr })
+  );
+};
+
+(async () => {
+  const txs = await getTxData();
+  const proposals = await getProposals();
+  const distr = {};
+  const voters = new Set();
+  const votes = txs.map(t => {
+    const tx = Tx.fromRaw(t.raw);
+    const withdrawalTx = isWithdraw(tx);
+    if (isVote(tx) || withdrawalTx) {
+      const voter = tx.inputs[1].signer; // balance card signer
+      voters.add(voter);
+      const proposalId = getProposalId(tx, proposals, voter);
+      if (!proposalId) {
+        return;
+      }
+      
+      const proposalVotes = distr[proposalId] = distr[proposalId] || {};
+
+      let votes = getVotes(tx);
+      const prevVote = (proposalVotes[voter] || 0);
+      
+      // invert withdrawal value for No Box, so it negates nicely when summed up
+      if (prevVote < 0 && withdrawalTx) {
+        votes = -votes;
+      }
+      
+      // aggregate votes by the voter for the proposal
+      proposalVotes[voter] = (proposalVotes[voter] || 0) + votes;
+
+      return { 
+        proposalId, 
+        voter,
+        votes,
+        type: withdrawalTx ? 'w' : 'v'
+      };
+    }
+    return;
+  });
+
+  // prepend votes array with vote 0 for each active voter for each proposal
+  // so once summed up we see 0 votes
+  const votersArr = new Array(...voters);
+  let votesWithDefault = [];
+  proposals.forEach(p => {
+    votesWithDefault = votesWithDefault.concat(
+      votersArr.map(v => ({
+        proposalId: p.proposalId,
+        voter: v,
+        votes: 0,
+        type: 'v'
+      }))
+    );
+  });
+  votesWithDefault = votesWithDefault.concat(votes);  
+  
+  fs.writeFileSync(`./build/rawVotes.csv`, votesWithDefault.filter(v => !!v).map(v => 
+    `${v.proposalId};${v.voter};${v.type};${v.votes}`  
+  ).join('\n'));
+
+  const groupedDistr = Object.entries(distr).map(([proposalId, votes]) => 
+    ({ proposalId, distr: countByNumberOfVotes(Object.entries(votes)) })
+  );
+
+
+  const distributionByVoteCSV = [].concat(...groupedDistr.map((v) =>
+      Object.entries(v.distr).map(([votes, count]) => `${v.proposalId};${votes};${count}`)
+  ));
+  
+  fs.writeFileSync(`./build/distributionByVote.csv`, distributionByVoteCSV.join('\n'))
+  console.log('Distribution by vote saved to:', './build/distributionByVote.csv');  
+
+  fs.writeFileSync(`./build/distr.json`, JSON.stringify(distr, null, 2));
+
+  const flatDistr = [].concat(...Object.entries(distr).map(([proposalId, votes]) =>
+    Object.entries(votes).map((v) => [proposalId, ...v])
+  ));
+
+  fs.writeFileSync(`./build/distr.csv`, flatDistr.map(v => 
+    `${v[0]};${v[1]};${v[2]}`  
+  ).join('\n'));
+
+  console.log("total txs: ", txs.length);
+  console.log('voters:', voters.size);
+  return;  
+})();
+

--- a/scripts/scanResults.js
+++ b/scripts/scanResults.js
@@ -13,8 +13,8 @@ const proposalData = 'https://www.npoint.io/documents/217ecb17f01746799a3b';
 const proposalsFile = 'build/proposals.json';
 const votesFile = 'build/voteTxs.json';
 const leapNetworkNode = 'https://testnet-node.leapdao.org';
-const startBlock = 88632; // September 8, 2019, 10:39:33 UTC
-const endBlock = 90780; // September 9, 2019, 16:00:41 UTC
+const startBlock = 87632; 
+const endBlock = 91470;
 /** ---------------- */
 
 const factor18 = ethers.utils.bigNumberify(String(10 ** 18));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,35 @@
 # yarn lockfile v1
 
 
+"@types/bn.js@*":
+  version "4.11.5"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.5.tgz#40e36197433f78f807524ec623afcf0169ac81dc"
+  integrity sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*":
+  version "12.7.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.4.tgz#64db61e0359eb5a8d99b55e05c729f130a678b04"
+  integrity sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==
+
 "@types/node@^10.3.2":
   version "10.14.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.17.tgz#b96d4dd3e427382482848948041d3754d40fd5ce"
   integrity sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ==
+
+"@types/underscore@*":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.9.2.tgz#2c4f7743287218f5c2d9a83db3806672aa48530d"
+  integrity sha512-KgOKTAD+9X+qvZnB5S1+onqKc4E+PZ+T6CM/NA5ohRPLHJXb+yCJMVf8pWOnvuBuKFNUAJW8N97IA6lba6mZGg==
+
+"@types/web3@^1.0.18":
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/@types/web3/-/web3-1.0.19.tgz#46b85d91d398ded9ab7c85a5dd57cb33ac558924"
+  integrity sha512-fhZ9DyvDYDwHZUp5/STa9XW2re0E8GxoioYJ4pEUZ13YHpApSagixj7IAdoYH5uAK+UalGq6Ml8LYzmgRA/q+A==
+  dependencies:
+    "@types/bn.js" "*"
+    "@types/underscore" "*"
 
 aes-js@3.0.0:
   version "3.0.0"
@@ -273,6 +298,19 @@ escape-string-regexp@1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+ethereumjs-util@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.0.0.tgz#f14841c182b918615afefd744207c7932c8536c0"
+  integrity sha512-E3yKUyl0Fs95nvTFQZe/ZSNcofhDzUsDlA5y2uoRmf1+Ec7gpGhNCsgKkZBRh7Br5op8mJcYF/jFbmjj909+nQ==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    ethjs-util "^0.1.6"
+    keccak "^1.0.2"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
+
 ethereumjs-util@6.1.0, ethereumjs-util@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz#e9c51e5549e8ebd757a339cc00f5380507e799c8"
@@ -302,7 +340,7 @@ ethers@^4.0.13:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethjs-util@0.1.6:
+ethjs-util@0.1.6, ethjs-util@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
@@ -477,6 +515,18 @@ js-sha3@0.5.7:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
   integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
+jsbi-utils@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jsbi-utils/-/jsbi-utils-1.0.1.tgz#39ecf025b3dd80d9ae577105cf53eb567b227352"
+  integrity sha512-WfKCFGRRBJGjln99Cukvrvp6KJFqXNTOMwlMs4cImf9C7/65K6u8bOFK25rVVTY3piWU6eAb6gjj5568u6SrnA==
+  dependencies:
+    jsbi "^2.0.5"
+
+jsbi@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-2.0.5.tgz#82589011da87dc59b4b549d94dcef51a9155f6fe"
+  integrity sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ==
+
 jsbi@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-3.1.0.tgz#d5491c1dd9423ece70af525866cae4adc0de9642"
@@ -498,6 +548,21 @@ lcid@^2.0.0:
   integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
   dependencies:
     invert-kv "^2.0.0"
+
+leap-core@^0.35.1:
+  version "0.35.1"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.35.1.tgz#74d56375b1d6d327a264bb32afe6786f341e6e1d"
+  integrity sha512-ovvNd+mPLX5ynVC3bs/fIlP7Xp+rV6Zz/vDnJexzBmsiBR3DIYScts+uW4NxP7um6LwYk//99EeLhujnuQN+iA==
+  dependencies:
+    "@types/web3" "^1.0.18"
+    ethereumjs-util "6.0.0"
+    jsbi-utils "^1.0.0"
+    node-fetch "^2.3.0"
+
+leap-provider@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/leap-provider/-/leap-provider-1.1.1.tgz#74b826422f911b5b8c3d141926873e6260d027b9"
+  integrity sha512-4X/gie8XTW6mZXskvFQR6gOptomQprs+hA2AT8U7DW+vUt7VTm86fxUiTPL2FSLG3EDWl1wQYWzWxgQN16GDpQ==
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -597,6 +662,11 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^2.3.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 npm-run-path@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
Resolves: https://github.com/deora-earth/voting-frontend/issues/145
Execute with:

```
node scripts/scanResults
```

On a first run it will download all the txs for a block inverval. Block interval is set in the code so far, see config section on top. Downloaded txs are cached in `./build/voteTxs.json`, remove it if you want to redownload.

On a first run it will download proposals from npoint and cache them in `./build/proposals.json`. Remove if you want to redownload.

Main product of the script: `./build/distributionByVote.csv` CSV file.

Sample graph:
![image](https://user-images.githubusercontent.com/163447/64612182-dcf73d80-d3db-11e9-8c9d-dd5405e3eb1e.png)

